### PR TITLE
Disable OIDC extension on FIPS platform

### DIFF
--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -164,6 +164,7 @@ spec:
                       - '--enable-multi-instrumentation=true'
                     extra_args:
                       - '--enable-cr-metrics=true'
+                      - '--fips-disabled-components=extension.oidc'
                     extra_env:
                       - name: RELATED_IMAGE_COLLECTOR
                         value: opentelemetry-collector-container-pullspec


### PR DESCRIPTION
This can be merged with operator 0.110.0