### PR TITLE
Workaround shallow git submodule clone by hardcoding version

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -12,7 +12,7 @@ WORKDIR /opt/app-root/src/opentelemetry-operator
 RUN exportOrFail() { echo $1; if [[ $1 == *= ]]; then echo "Error: empty variable assignment"; exit 1; else export "$1"; fi } && \
     exportOrFail VERSION_PKG="github.com/open-telemetry/opentelemetry-operator/internal/version" && \
     exportOrFail BUILD_DATE=`date -u +'%Y-%m-%dT%H:%M:%SZ'` && \
-    exportOrFail GIT_LATEST_TAG_AND_SHA=`git describe --tags --always | sed 's/^v//'` && \
+    exportOrFail GIT_LATEST_TAG_AND_SHA=0.113.0 && \
     exportOrFail OTELCOL_VERSION=`grep -v '\#' versions.txt | grep opentelemetry-collector | awk -F= '{print $2}'` && \
     exportOrFail TARGETALLOCATOR_VERSION=`grep -v '\#' versions.txt | grep targetallocator | awk -F= '{print $2}'` && \
     exportOrFail OPERATOR_OPAMP_BRIDGE_VERSION=`grep -v '\#' versions.txt | grep operator-opamp-bridge | awk -F= '{print $2}'` && \


### PR DESCRIPTION
Workaround shallow git submodule clone by hardcoding version

Ref. https://issues.redhat.com/browse/TRACING-5019