### PR TITLE
Drop rpm-lockfile-prototype bundle-patch/rpms.in.yaml from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
   "dockerfile": {
     "postUpgradeTasks": {
       "commands": [
-        "rpm-lockfile-prototype rpms.in.yaml",
-        "rpm-lockfile-prototype bundle-patch/rpms.in.yaml --outfile bundle-patch/rpms.lock.yaml"
+        "rpm-lockfile-prototype rpms.in.yaml"
       ],
       "fileFilters": ["**/rpms.lock.yaml"]
     }


### PR DESCRIPTION
This command is currently not allowed in `postUpgradeTasks`. See https://issues.redhat.com/browse/KFLUXBUGS-1928 for context.