### PR TITLE
Install logging and loki from stable-6.1 channel

### DIFF
--- a/.tekton/integration-tests/resources/install.yaml
+++ b/.tekton/integration-tests/resources/install.yaml
@@ -21,7 +21,7 @@ metadata:
   name: loki-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-6.0
+  channel: stable-6.1
   installPlanApproval: Automatic
   name: loki-operator
   source: redhat-operators
@@ -138,7 +138,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable-6.0
+  channel: stable-6.1
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators


### PR DESCRIPTION
Use Cluster Logging and Loki Operator version 6.1 which has support for OTLP logs ingestion required by our interoperability tests. 