### PR TITLE
Update IDMS step in readme file. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,35 @@ Once the components are released to prod, create another PR `Release - update ca
 
 Images can be found at https://quay.io/organization/redhat-user-workloads (search for `rhosdt-tenant/otel`).
 
+### Deploy Image Digest Mirror Set
+
+Before using the bundle or catalog method for installing the operator, the ImageDigestMirrorSet needs to be created. The bundle and catalog uses pullspecs from `registry.redhat.io` which are not available before the release. Therefore the images need to be re-mapped.
+
+From https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#releasing-a-fbc-component
+
+```yaml
+kubectl apply -f - <<EOF
+apiVersion: config.openshift.io/v1
+kind: ImageDigestMirrorSet
+metadata:
+  name: otel-idms
+spec:
+  imageDigestMirrors:
+  - source: registry.redhat.io/rhosdt/opentelemetry-collector-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector
+  - source: registry.redhat.io/rhosdt/opentelemetry-target-allocator-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator
+  - source: registry.redhat.io/rhosdt/opentelemetry-rhel8-operator
+    mirrors:
+       - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator
+  - source: registry.redhat.io/rhosdt/opentelemetry-operator-bundle
+    mirrors:
+       - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-bundle
+EOF
+```
+
 ### Deploy bundle
 
 get latest pullspec from `kubectl get component otel-bundle-quay -o yaml`, then run:
@@ -130,35 +159,6 @@ kubectl delete CatalogSource konflux-catalog-otel -n openshift-marketplace
 ```
 
 `Konflux catalog OTEL` menu should appear in the OCP console under Operators->OperatorHub.
-
-#### Mirror images
-
-The catalog uses pullspecs from `registry.redhat.io` which are not available before the release. Therefore the images need to be re-mapped.
-
-From https://konflux.pages.redhat.com/docs/users/getting-started/building-olm-products.html#releasing-a-fbc-component
-
-```yaml
-kubectl apply -f - <<EOF
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-  name: fbc-testing-idms
-spec:
-  imageDigestMirrors:
-  - source: registry.redhat.io/rhosdt/opentelemetry-collector-rhel8
-    mirrors:
-      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector
-  - source: registry.redhat.io/rhosdt/opentelemetry-target-allocator-rhel8
-    mirrors:
-      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator
-  - source: registry.redhat.io/rhosdt/opentelemetry-rhel8-operator
-    mirrors:
-       - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator
-  - source: registry.redhat.io/rhosdt/opentelemetry-operator-bundle
-    mirrors:
-       - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-bundle
-EOF
-```
 
 ### Inspect bundle image
 


### PR DESCRIPTION
Update the README to create IDMS before using either the bundle or catalog method of installing the operator. With this documented we can get rid of the -quay bundle and use the main bundle instead. 