### PR TITLE
Add FBC integration jobs to test operator upgrade.

### DIFF
--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-14.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[opentelemetry-upgrade-tests]"
+  name: opentelemetry-operator-upgrade-test-fbc
+spec:
+  description: |
+    This pipeline automates the process of running upgrade tests for OpenShift OpenTelemetry Operator
+    using a ROSA (Red Hat OpenShift Service on AWS) cluster. The pipeline fetches the FBC fragment image, provisions
+    the ROSA cluster, runs the upgrade tests, collects artifacts,
+    and finally deprovisions the ROSA cluster.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: test-name
+      description: 'The name of the test corresponding to a defined Konflux integration test.'
+      default: 'opentelemetry-operator-upgrade-test-fbc'
+      type: string
+    - name: namespace
+      description: 'Namespace to run tests in'
+      default: 'openshift-opentelemetry-operator'
+      type: string
+    - name: operator_csv_version
+      description: Version of OpenTelemetry Operator CSV
+      type: string
+    - name: otel_version
+      description: Version of OpenTelemetry operator and collector
+      type: string
+    - name: otel_tests_branch
+      description: "The repository branch from which to run the tests"
+      type: string
+    - name: PACKAGE_NAME
+      description: "Package name for the bundle"
+      default: "opentelemetry-product"
+      type: string
+    - name: CHANNEL_NAME
+      description: "Channel name for the bundle"
+      default: "stable"
+      type: string
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.14."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhosdt/opentelemetry-collector-rhel8
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector
+                  - source: registry.redhat.io/rhosdt/opentelemetry-target-allocator-rhel8
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator
+                  - source: registry.redhat.io/rhosdt/opentelemetry-rhel8-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator
+                  - source: registry.redhat.io/rhosdt/opentelemetry-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-bundle
+    - name: opentelemetry-upgrade-tests
+      description: Task to run tests from service repository
+      runAfter:
+        - provision-cluster
+      params:
+        - name: OTEL_TESTS_BRANCH
+          value: $(params.otel_tests_branch)
+        - name: OTEL_VERSION
+          value: $(params.otel_version)
+        - name: OPERATOR_CSV_VERSION
+          value: $(params.operator_csv_version)
+        - name: FBC_FRAGMENT
+          value: "$(tasks.parse-metadata.results.component-container-image)"
+      taskSpec:
+        params:
+          - name: OTEL_TESTS_BRANCH
+            type: string
+          - name: OTEL_VERSION
+            type: string
+          - name: OPERATOR_CSV_VERSION
+            type: string
+          - name: FBC_FRAGMENT
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-upgrade-tests
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: FBC_FRAGMENT
+                value: "$(params.FBC_FRAGMENT)"
+              - name: OTEL_VERSION
+                value: "$(params.OTEL_VERSION)"
+              - name: OPERATOR_CSV_VERSION
+                value: "$(params.OPERATOR_CSV_VERSION)"
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              OTEL_TESTS_BRANCH=$(params.OTEL_TESTS_BRANCH)
+              
+              echo "Install dependencies"
+              dnf -y install jq vim unzip git make
+
+              echo "Install GO"
+              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
+              tar -C /usr/local -xzf /go.tar.gz
+              export PATH=$PATH:/usr/local/go/bin
+              # Set the Go path and Go cache environment variables
+              export GOPATH=/tmp/go
+              export GOBIN=/tmp/go/bin
+              export GOCACHE=/tmp/.cache/go-build
+              export PATH=$PATH:/tmp/go/bin
+
+              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
+              mkdir -p /tmp/go/bin $GOCACHE \
+                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
+              go version
+
+              echo "Install Chainsaw"
+              go install github.com/kyverno/chainsaw@v0.2.12
+
+              echo "Install kubectl and oc"
+              cd /tmp/ \
+              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
+              && tar -xvzf oc.tar.gz \
+              && chmod +x kubectl oc \
+              && mv oc kubectl /usr/local/bin/
+
+              echo "Install the latest version of logcli"
+              curl -LO https://github.com/grafana/loki/releases/latest/download/logcli-linux-amd64.zip \
+              && unzip logcli-linux-amd64.zip \
+              && chmod +x logcli-linux-amd64 \
+              && mv logcli-linux-amd64 /usr/local/bin/logcli
+
+              echo "Run e2e tests"
+              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              cd /tmp/otel-tests 
+              git checkout $OTEL_TESTS_BRANCH
+
+              #Enable user workload monitoring
+              oc apply -f tests/e2e-openshift/otlp-metrics-traces/01-workload-monitoring.yaml
+              unset NAMESPACE
+
+              # Execute OpenTelemetry e2e tests
+              mkdir -p .testresults/e2e
+              
+              chainsaw test tests/e2e-openshift-upgrade --values - <<EOF
+              upgrade_fbc_image: $FBC_FRAGMENT
+              upgrade_otel_version: $OTEL_VERSION
+              upgrade_operator_csv_name: $OPERATOR_CSV_VERSION
+              EOF

--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-17.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-17.yaml
@@ -1,0 +1,258 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[opentelemetry-upgrade-tests]"
+  name: opentelemetry-operator-upgrade-test-fbc
+spec:
+  description: |
+    This pipeline automates the process of running upgrade tests for OpenShift OpenTelemetry Operator
+    using a ROSA (Red Hat OpenShift Service on AWS) cluster. The pipeline fetches the FBC fragment image, provisions
+    the ROSA cluster, runs the upgrade tests, collects artifacts,
+    and finally deprovisions the ROSA cluster.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: test-name
+      description: 'The name of the test corresponding to a defined Konflux integration test.'
+      default: 'opentelemetry-operator-upgrade-test-fbc'
+      type: string
+    - name: namespace
+      description: 'Namespace to run tests in'
+      default: 'openshift-opentelemetry-operator'
+      type: string
+    - name: operator_csv_version
+      description: Version of OpenTelemetry Operator CSV
+      type: string
+    - name: otel_version
+      description: Version of OpenTelemetry operator and collector
+      type: string
+    - name: otel_tests_branch
+      description: "The repository branch from which to run the tests"
+      type: string
+    - name: PACKAGE_NAME
+      description: "Package name for the bundle"
+      default: "opentelemetry-product"
+      type: string
+    - name: CHANNEL_NAME
+      description: "Channel name for the bundle"
+      default: "stable"
+      type: string
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.17."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhosdt/opentelemetry-collector-rhel8
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector
+                  - source: registry.redhat.io/rhosdt/opentelemetry-target-allocator-rhel8
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator
+                  - source: registry.redhat.io/rhosdt/opentelemetry-rhel8-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator
+                  - source: registry.redhat.io/rhosdt/opentelemetry-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-bundle
+    - name: opentelemetry-upgrade-tests
+      description: Task to run tests from service repository
+      runAfter:
+        - provision-cluster
+      params:
+        - name: OTEL_TESTS_BRANCH
+          value: $(params.otel_tests_branch)
+        - name: OTEL_VERSION
+          value: $(params.otel_version)
+        - name: OPERATOR_CSV_VERSION
+          value: $(params.operator_csv_version)
+        - name: FBC_FRAGMENT
+          value: "$(tasks.parse-metadata.results.component-container-image)"
+      taskSpec:
+        params:
+          - name: OTEL_TESTS_BRANCH
+            type: string
+          - name: OTEL_VERSION
+            type: string
+          - name: OPERATOR_CSV_VERSION
+            type: string
+          - name: FBC_FRAGMENT
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-upgrade-tests
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: FBC_FRAGMENT
+                value: "$(params.FBC_FRAGMENT)"
+              - name: OTEL_VERSION
+                value: "$(params.OTEL_VERSION)"
+              - name: OPERATOR_CSV_VERSION
+                value: "$(params.OPERATOR_CSV_VERSION)"
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              OTEL_TESTS_BRANCH=$(params.OTEL_TESTS_BRANCH)
+              
+              echo "Install dependencies"
+              dnf -y install jq vim unzip git make
+
+              echo "Install GO"
+              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
+              tar -C /usr/local -xzf /go.tar.gz
+              export PATH=$PATH:/usr/local/go/bin
+              # Set the Go path and Go cache environment variables
+              export GOPATH=/tmp/go
+              export GOBIN=/tmp/go/bin
+              export GOCACHE=/tmp/.cache/go-build
+              export PATH=$PATH:/tmp/go/bin
+
+              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
+              mkdir -p /tmp/go/bin $GOCACHE \
+                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
+              go version
+
+              echo "Install Chainsaw"
+              go install github.com/kyverno/chainsaw@v0.2.12
+
+              echo "Install kubectl and oc"
+              cd /tmp/ \
+              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
+              && tar -xvzf oc.tar.gz \
+              && chmod +x kubectl oc \
+              && mv oc kubectl /usr/local/bin/
+
+              echo "Install the latest version of logcli"
+              curl -LO https://github.com/grafana/loki/releases/latest/download/logcli-linux-amd64.zip \
+              && unzip logcli-linux-amd64.zip \
+              && chmod +x logcli-linux-amd64 \
+              && mv logcli-linux-amd64 /usr/local/bin/logcli
+
+              echo "Run e2e tests"
+              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              cd /tmp/otel-tests 
+              git checkout $OTEL_TESTS_BRANCH
+
+              #Enable user workload monitoring
+              oc apply -f tests/e2e-openshift/otlp-metrics-traces/01-workload-monitoring.yaml
+              unset NAMESPACE
+
+              # Execute OpenTelemetry e2e tests
+              mkdir -p .testresults/e2e
+              
+              chainsaw test tests/e2e-openshift-upgrade --values - <<EOF
+              upgrade_fbc_image: $FBC_FRAGMENT
+              upgrade_otel_version: $OTEL_VERSION
+              upgrade_operator_csv_name: $OPERATOR_CSV_VERSION
+              EOF


### PR DESCRIPTION
The PR adds jobs for min OCP 4.14 and max OCP 4.17 versions.