### PR TITLE
update renovatebot config

### DIFF
--- a/bundle-patch/bundle.env
+++ b/bundle-patch/bundle.env
@@ -8,4 +8,7 @@ OTEL_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/op
 
 OTEL_TARGET_ALLOCATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator@sha256:90c7a0d626991473bbb165648652d0da8711786e5ea81f7feb230bbeaea97e97
 
+# https://catalog.redhat.com/software/containers/openshift4/ose-kube-rbac-proxy/5cdb2634dd19c778293b4d98
+# Copy the image listed in "Get this image" > "Manifest List Digest" and make sure it's multi-arch (verify with "skopeo inspect --raw docker://registry.redhat.io/...")
+# renovate: follow_tag=latest
 OSE_KUBE_RBAC_PROXY_PULLSPEC=registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:7efeeb8b29872a6f0271f651d7ae02c91daea16d853c50e374c310f044d8c76c

--- a/renovate.json
+++ b/renovate.json
@@ -1,18 +1,21 @@
 {
-  "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "ignoreDeps": [
     "registry.redhat.io/openshift4/ose-operator-registry",
     "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
   ],
-  "packageRules": [
-    {
-      "matchFileNames": ["bundle-patch/bundle.env"],
-      "groupName": "bundle images"
-    }
-  ],
   "git-submodules": {
     "enabled": false
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update digest of container images in .env files",
+      "managerFilePatterns": ["/\\.env$/"],
+      "matchStrings": [
+        "# renovate: follow_tag=(?<currentValue>[a-z-]+?)\\s.+?=(?<packageName>[^@:]+?)@(?<currentDigest>.+?)\\s"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
* enable auto updates for registry.redhat.io images https://issues.redhat.com/browse/TRACING-5529
* add schema
* do not extend from base config. MintMaker already extends from the base config implicitly, and by linking to the main branch directly we could include configs which are not deployed yet https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#create-your-custom-configuration