### PR TITLE
fix: replace unsafe yaml.load() with yaml.safe_load() in bundle-patch scripts

### DIFF
--- a/bundle-patch/patch_annotations.py
+++ b/bundle-patch/patch_annotations.py
@@ -7,10 +7,10 @@ from datetime import datetime
 annotations_file = "metadata/annotations.yaml"
 
 with open('./patch_annotations.yaml') as pf:
-    patch = yaml.load(pf)
+    patch = yaml.safe_load(pf)
 
     with open(annotations_file, 'r') as f:
-        upstream_annotations = yaml.load(f)
+        upstream_annotations = yaml.safe_load(f)
         upstream_annotations['annotations'].update(patch['extra_annotations'])
 
     with open(annotations_file, 'w') as f:

--- a/bundle-patch/patch_csv.py
+++ b/bundle-patch/patch_csv.py
@@ -28,7 +28,7 @@ def load_manifest(pathn):
       return None
    try:
       with open(pathn, "r") as f:
-         return yaml.load(f)
+         return yaml.safe_load(f)
    except FileNotFoundError:
       print("File can not found")
       exit(2)
@@ -83,7 +83,7 @@ upstream_csv['spec']['relatedImages'] = [
     {'name': 'ose-rbac-proxy', 'image': os.getenv('OSE_KUBE_RBAC_PROXY_PULLSPEC')}]
 
 with open('./patch_csv.yaml') as pf:
-    patch = yaml.load(pf)
+    patch = yaml.safe_load(pf)
 
     if patch['metadata'].get('labels') is not None:
         upstream_csv['metadata']['labels'].update(patch['metadata']['labels'])


### PR DESCRIPTION

This resolves CWE-502 unsafe deserialization vulnerabilities identified by security scanning. The yaml.load() function can execute arbitrary Python code when processing untrusted input, while yaml.safe_load() only loads basic YAML tags safely.

Changes:
- bundle-patch/patch_annotations.py: Replace yaml.load() calls with yaml.safe_load()
- bundle-patch/patch_csv.py: Replace yaml.load() calls with yaml.safe_load()

🤖 Generated with [Claude Code](https://claude.ai/code)