### PR TITLE
Remove the project name from snyk

### DIFF
--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -288,7 +288,7 @@ spec:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: ARGS
-      value: "--project-name=red-hat-openshift-distributed-tracing --report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
+      value: "--report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/.tekton/multi-arch-build-pipeline.yaml
+++ b/.tekton/multi-arch-build-pipeline.yaml
@@ -288,7 +288,7 @@ spec:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: ARGS
-      value: "--report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
+      value: "--project-name=$(params.snyk-project) --report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -558,6 +558,10 @@ spec:
     description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
     name: build-platforms
     type: array
+  - name: snyk-project
+    type: string
+    description: Snyk project name
+    default: 'red-hat-openshift-distributed-tracing'
   workspaces:
   - name: git-auth
     optional: true

--- a/.tekton/otel-collector-pull-request.yaml
+++ b/.tekton/otel-collector-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
       - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
+  - name: snyk-project
+    value: otel-collector
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/otel-collector-push.yaml
+++ b/.tekton/otel-collector-push.yaml
@@ -53,6 +53,8 @@ spec:
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
+  - name: snyk-project
+    value: otel-collector
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/otel-operator-pull-request.yaml
+++ b/.tekton/otel-operator-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
       - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
+  - name: snyk-project
+    value: otel-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/otel-operator-push.yaml
+++ b/.tekton/otel-operator-push.yaml
@@ -53,6 +53,8 @@ spec:
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
+  - name: snyk-project
+    value: otel-operator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/otel-target-allocator-pull-request.yaml
+++ b/.tekton/otel-target-allocator-pull-request.yaml
@@ -55,6 +55,8 @@ spec:
       - linux/arm64
 #      - linux/ppc64le
 #      - linux/s390x
+  - name: snyk-project
+    value: otel-target-allocator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/otel-target-allocator-push.yaml
+++ b/.tekton/otel-target-allocator-push.yaml
@@ -53,6 +53,8 @@ spec:
       - linux/arm64
       - linux/ppc64le
       - linux/s390x
+  - name: snyk-project
+    value: otel-target-allocator
   pipelineRef:
     name: build-pipeline
   taskRunTemplate: {}

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -228,7 +228,7 @@ spec:
     - name: image-url
       value: "$(tasks.build-container.results.IMAGE_URL)"
     - name: ARGS
-      value: "--report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
+      value: "--project-name=$(params.snyk-project) --report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
   - name: clamav-scan
     taskRef:
       resolver: bundles
@@ -421,6 +421,10 @@ spec:
     type: string
     description: Build a source image.
     default: 'false'
+  - name: snyk-project
+    type: string
+    description: Snyk project name
+    default: 'red-hat-openshift-distributed-tracing'
   workspaces:
   - name: git-auth
     optional: true

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -228,7 +228,7 @@ spec:
     - name: image-url
       value: "$(tasks.build-container.results.IMAGE_URL)"
     - name: ARGS
-      value: "--project-name=red-hat-openshift-distributed-tracing --report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
+      value: "--report --org=0eebca54-4fa1-4638-9ac6-f95f789a9d3e"
   - name: clamav-scan
     taskRef:
       resolver: bundles


### PR DESCRIPTION
* https://github.com/konflux-ci/build-definitions/tree/main/task/sast-snyk-check-oci-ta/0.4
* It seems the project name is not set properly here https://github.com/konflux-ci/build-definitions/blob/main/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml#L228 
* https://konflux.pages.redhat.com/docs/users/testing/sast-tasks.html#snyk-results 

Snyk UI: https://app.snyk.io/org/red-hat-openshift-distributed-tracing/projects?groupBy=targets&before&after&searchQuery=&sortBy=highest+severity&filters[Show]=&filters[Integrations]=&filters[CollectionIds]= 

If the `project-name` is hardcoded all components upload the report to the same project which is difficult to analyze 

<img width="3840" height="2013" alt="image" src="https://github.com/user-attachments/assets/6813a9c3-43b9-4986-a713-242c916150ba" />


<img width="3840" height="2013" alt="image" src="https://github.com/user-attachments/assets/13bfdb3e-e3f3-4fc7-b9ee-22adbaa49aba" />


Issue reported here https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1758108977775779 
