### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for otel-target-allocator-main

### DIFF
--- a/Dockerfile.targetallocator
+++ b/Dockerfile.targetallocator
@@ -46,6 +46,7 @@ LABEL release="0.135.0-1" \
       name="rhosdt/opentelemetry-target-allocator-rhel8" \
       summary="OpenTelemetry Target allocator" \
       description="Prometheus target allocator for the OpenTelemetry collector" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       io.k8s.description="Target allocator for the OpenTelemetry collector." \
       io.openshift.expose-services="80:http" \
       io.openshift.tags="monitoring" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
