### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for otel-bundle-main

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -55,6 +55,7 @@ LABEL release="${VERSION}" \
       io.k8s.description="Bundle for OpenTelemetry operator" \
       # TODO check if this is correct
       com.redhat.component="rhosdt" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       io.openshift.tags="tracing" \
       io.k8s.display-name="OpenTelemetry Operator Bundle" \
       url="https://github.com/open-telemetry/opentelemetry-operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
