### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for otel-collector-main

### DIFF
--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -52,6 +52,7 @@ LABEL release="${VERSION}" \
       distribution-scope="public" \
       url="https://github.com/open-telemetry/opentelemetry-operator" \
       com.redhat.component="opentelemetry-collector-container" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       name="rhosdt/opentelemetry-collector-rhel8" \
       summary="OpenTelemetry Collector" \
       description="Collector for the distributed tracing system" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
