### PR TITLE
Bump OpenTelemetry to operator 0.152.0 / collector 0.152.1

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -25,7 +25,7 @@ RUN ./update_bundle.sh && cat manifests/opentelemetry-operator.clusterservicever
 
 FROM scratch
 
-ARG VERSION=0.144.0-3
+ARG VERSION=0.152.0-1
 
 WORKDIR /
 

--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -33,7 +33,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.144.0-3
+ARG VERSION=0.152.0-1
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -55,7 +55,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.144.0-3
+ARG VERSION=0.152.0-1
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/Dockerfile.targetallocator
+++ b/Dockerfile.targetallocator
@@ -29,7 +29,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.144.0-3
+ARG VERSION=0.152.0-1
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -17,11 +17,11 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     console.openshift.io/operator-monitoring-default: "true"
-    olm.skipRange: '>=0.33.0 <0.144.0-3'
-  name: opentelemetry-operator.v0.144.0-3
+    olm.skipRange: '>=0.33.0 <0.152.0-1'
+  name: opentelemetry-operator.v0.152.0-1
 spec:
-  version: 0.144.0-3
-  replaces: opentelemetry-operator.v0.144.0-2
+  version: 0.152.0-1
+  replaces: opentelemetry-operator.v0.144.0-3
   description: |-
     Red Hat build of OpenTelemetry is a collection of tools, APIs, and SDKs. You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior.
     This operator was previously called Red Hat OpenShift distributed tracing data collection.

--- a/catalog/catalog-template.yaml
+++ b/catalog/catalog-template.yaml
@@ -86,9 +86,6 @@ entries:
   - name: opentelemetry-operator.v0.144.0-3
     replaces: opentelemetry-operator.v0.144.0-2
     skipRange: '>=0.33.0 <0.144.0-3'
-  - name: opentelemetry-operator.v0.152.0-1
-    replaces: opentelemetry-operator.v0.144.0-3
-    skipRange: '>=0.33.0 <0.152.0-1'
   name: stable
   package: opentelemetry-product
   schema: olm.channel

--- a/catalog/catalog-template.yaml
+++ b/catalog/catalog-template.yaml
@@ -86,6 +86,9 @@ entries:
   - name: opentelemetry-operator.v0.144.0-3
     replaces: opentelemetry-operator.v0.144.0-2
     skipRange: '>=0.33.0 <0.144.0-3'
+  - name: opentelemetry-operator.v0.152.0-1
+    replaces: opentelemetry-operator.v0.144.0-3
+    skipRange: '>=0.33.0 <0.152.0-1'
   name: stable
   package: opentelemetry-product
   schema: olm.channel


### PR DESCRIPTION
## Summary
- Bump OpenTelemetry operator from 0.144.0 to 0.152.0 and collector to 0.152.1
- Update bundle version from `0.144.0-3` to `0.152.0-1` across all Dockerfiles, CSV patch, and catalog template
- Add new catalog entry for `0.152.0-1` replacing `0.144.0-3`

## Changes
- `Dockerfile.operator`, `Dockerfile.collector`, `Dockerfile.bundle`, `Dockerfile.targetallocator`: `ARG VERSION=0.152.0-1`
- `bundle-patch/patch_csv.yaml`: updated version, name, replaces, and skipRange
- `catalog/catalog-template.yaml`: added new channel entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)