### PR TITLE
Fix bundle CPE label to pass enforce-cpe-label release check

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -54,8 +54,7 @@ LABEL release="${VERSION}" \
       distribution-scope="public" \
       description="Bundle for OpenTelemetry operator" \
       io.k8s.description="Bundle for OpenTelemetry operator" \
-      # TODO check if this is correct
-      com.redhat.component="rhosdt" \
+      com.redhat.component="opentelemetry-operator-bundle-container" \
       io.openshift.tags="tracing" \
       io.k8s.display-name="OpenTelemetry Operator Bundle" \
       url="https://github.com/open-telemetry/opentelemetry-operator" \


### PR DESCRIPTION
## Summary
- Fix `com.redhat.component` label in `Dockerfile.bundle` from `"rhosdt"` to `"opentelemetry-operator-bundle-container"`
- Remove stale `# TODO check if this is correct` comment that was there since the label was first added
- This fixes the Konflux release failure at `step-enforce-cpe-label` in the `check-labels` task

## Test plan
- [ ] Re-run the Konflux release after merge and verify the `check-labels` task passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)