### PR TITLE
Fix git clone URL to use os-observability org in e2e and upgrade test pipelines

### DIFF
--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-14.yaml
@@ -587,7 +587,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
                             
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              git clone https://github.com/os-observability/opentelemetry-operator.git /tmp/otel-tests
               cd /tmp/otel-tests 
               git checkout $OTEL_TESTS_BRANCH
 

--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-18.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-18.yaml
@@ -590,7 +590,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              git clone https://github.com/os-observability/opentelemetry-operator.git /tmp/otel-tests
               cd /tmp/otel-tests 
               git checkout $OTEL_TESTS_BRANCH
 

--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-21-olmv1.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-e2e-test-pipeline-4-21-olmv1.yaml
@@ -692,7 +692,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              git clone https://github.com/os-observability/opentelemetry-operator.git /tmp/otel-tests
               cd /tmp/otel-tests
               git checkout $OTEL_TESTS_BRANCH
 

--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-14.yaml
@@ -220,7 +220,7 @@ spec:
               OTEL_TESTS_BRANCH=$(params.OTEL_TESTS_BRANCH)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              git clone https://github.com/os-observability/opentelemetry-operator.git /tmp/otel-tests
               cd /tmp/otel-tests 
               git checkout $OTEL_TESTS_BRANCH
 

--- a/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-18.yaml
+++ b/.tekton/integration-tests/pipelines/opentelemetry-operator-upgrade-test-fbc-pipeline-4-18.yaml
@@ -220,7 +220,7 @@ spec:
               OTEL_TESTS_BRANCH=$(params.OTEL_TESTS_BRANCH)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/opentelemetry-operator.git /tmp/otel-tests
+              git clone https://github.com/os-observability/opentelemetry-operator.git /tmp/otel-tests
               cd /tmp/otel-tests 
               git checkout $OTEL_TESTS_BRANCH
 


### PR DESCRIPTION
## Summary

- Replace `IshwarKanse/opentelemetry-operator` with `os-observability/opentelemetry-operator` as the git clone source in all e2e and upgrade test Tekton pipelines
- Affected pipelines:
  - `opentelemetry-operator-e2e-test-pipeline-4-14.yaml`
  - `opentelemetry-operator-e2e-test-pipeline-4-18.yaml`
  - `opentelemetry-operator-e2e-test-pipeline-4-21-olmv1.yaml`
  - `opentelemetry-operator-upgrade-test-fbc-pipeline-4-14.yaml`
  - `opentelemetry-operator-upgrade-test-fbc-pipeline-4-18.yaml`

## Test plan

- [x] Verify e2e test pipelines clone from the correct `os-observability` org repo
- [x] Verify upgrade test pipelines clone from the correct `os-observability` org repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)