### PR TITLE
Fix stray carriage return characters in patch_csv.yaml

### DIFF
--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -17,10 +17,10 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     console.openshift.io/operator-monitoring-default: "true"
-    olm.skipRange: '>=0.33.0 <0.152.1-1'
-  name: "opentelemetry-operator.v0.152.1\r-1"
+    olm.skipRange: '>=0.33.0 <0.152.1-1'
+  name: opentelemetry-operator.v0.152.1-1
 spec:
-  version: "0.152.1\r-1"
+  version: 0.152.1-1
   replaces: opentelemetry-operator.v0.144.0-3
   description: |-
     Red Hat build of OpenTelemetry is a collection of tools, APIs, and SDKs. You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior.


### PR DESCRIPTION
## Summary
- Removes `\r` (carriage return) characters introduced in #882 from the `name`, `version`, and `olm.skipRange` fields in `bundle-patch/patch_csv.yaml`
- These caused malformed CSV metadata (e.g. `0.152.1\r-1` instead of `0.152.1-1`)

## Test plan
- [ ] Verify the CSV metadata renders correctly without stray `\r` characters
- [ ] Confirm the bundle builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)