### PR TITLE
Update bundle [release-driver]

### DIFF
--- a/bundle-patch/bundle.env
+++ b/bundle-patch/bundle.env
@@ -2,8 +2,8 @@
 # The names must match the names of the Component CRs in Konflux: ${component.uppercase().replace('-','_')}_IMAGE_PULLSPEC
 # Separate variables by empty lines due to merge conflicts
 
-OTEL_COLLECTOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector@sha256:2e69ad14f9ebeb46e7d3e4a28435afb75e42f6073708a2a94b1bd6a5ad8c6c9f
+OTEL_COLLECTOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector@sha256:84259c439d3f03caf244b4127156bb26600c3a86b8a8a81973515edd8dee5311
 
-OTEL_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator@sha256:90d7a11dc3800ecef4aad7659a7e12d9b4033c804638447bb0766c26048bd391
+OTEL_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator@sha256:fc5f3241a89aa0c7d5f65e06402a4f72fe9e7d7ae82626d78d0aa569fd3e9de7
 
-OTEL_TARGET_ALLOCATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator@sha256:720830a68285b0be1c592ca89e1492da50cc784391fb70e99e74cdf5b132520d
+OTEL_TARGET_ALLOCATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-target-allocator@sha256:5511be25380d68eeac79662487154ffa9d0da598ea9e60a72fea897224675253

--- a/bundle-patch/bundle.env
+++ b/bundle-patch/bundle.env
@@ -2,7 +2,7 @@
 # The names must match the names of the Component CRs in Konflux: ${component.uppercase().replace('-','_')}_IMAGE_PULLSPEC
 # Separate variables by empty lines due to merge conflicts
 
-OTEL_COLLECTOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector@sha256:84259c439d3f03caf244b4127156bb26600c3a86b8a8a81973515edd8dee5311
+OTEL_COLLECTOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-collector@sha256:b4f7f653d44777a63bab4d88e26f7954d5ee2a5036f43d0e87c5f506b1aef838
 
 OTEL_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/otel/opentelemetry-operator@sha256:fc5f3241a89aa0c7d5f65e06402a4f72fe9e7d7ae82626d78d0aa569fd3e9de7
 


### PR DESCRIPTION
## Summary

We revert the last "Update bundle [release-driver]" commit (`de3318b`) to fall back to the state of the current stage build (`937276d`).

We only update the collector to the latest hash (`sha256:b4f7f653d44777a63bab4d88e26f7954d5ee2a5036f43d0e87c5f506b1aef838`), which includes the bump to 0.152.1 and x/net 0.55.0.

Operator and target-allocator remain at their `937276d` image digests.