### PR TITLE
Bump bundle version to 0.152.0-2

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -25,7 +25,7 @@ RUN ./update_bundle.sh && cat manifests/opentelemetry-operator.clusterservicever
 
 FROM scratch
 
-ARG VERSION=0.152.1-1
+ARG VERSION=0.152.1-2
 
 WORKDIR /
 

--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -33,7 +33,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.152.1-1
+ARG VERSION=0.152.1-2
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -55,7 +55,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.152.1-1
+ARG VERSION=0.152.1-2
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/Dockerfile.targetallocator
+++ b/Dockerfile.targetallocator
@@ -29,7 +29,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.152.1-1
+ARG VERSION=0.152.1-2
 
 RUN mkdir /licenses
 COPY opentelemetry-operator/LICENSE /licenses/.

--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -17,11 +17,11 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     console.openshift.io/operator-monitoring-default: "true"
-    olm.skipRange: '>=0.33.0 <0.152.0-1'
-  name: opentelemetry-operator.v0.152.0-1
+    olm.skipRange: '>=0.33.0 <0.152.0-2'
+  name: opentelemetry-operator.v0.152.0-2
 spec:
-  version: 0.152.0-1
-  replaces: opentelemetry-operator.v0.144.0-3
+  version: 0.152.0-2
+  replaces: opentelemetry-operator.v0.152.0-1
   description: |-
     Red Hat build of OpenTelemetry is a collection of tools, APIs, and SDKs. You use it to instrument, generate, collect, and export telemetry data (metrics, logs, and traces) for analysis in order to understand your software's performance and behavior.
     This operator was previously called Red Hat OpenShift distributed tracing data collection.


### PR DESCRIPTION
## Summary
- Bumps bundle version from `0.152.0-1` to `0.152.0-2`
- Updates `replaces` to point to `0.152.0-1`
- Updates `olm.skipRange` accordingly

**Note:** This PR should be rebased after #931 is merged.

## Test plan
- [ ] Run the release driver after merge to verify the bundle update is picked up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)